### PR TITLE
Fix persistance du thème en localStorage

### DIFF
--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -15,6 +15,7 @@ export default function ThemeSwitcher() {
   useEffect(() => {
     document.documentElement.classList.remove('light', 'dark');
     document.documentElement.classList.add(theme);
+    document.documentElement.style.colorScheme = theme;
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -3,20 +3,15 @@ import sunSVG from '/icons/sun.svg?raw';
 import moonSVG from '/icons/moon.svg?raw';
 
 export default function ThemeSwitcher() {
-  // État local pour le thème
+  // État local pour le thème, initialisé depuis localStorage (déjà appliqué au <html> par le script inline du Layout)
   const [theme, setTheme] = useState(() => {
     if (typeof window !== 'undefined') {
-      return (
-        localStorage.getItem('theme') ||
-        (window.matchMedia('(prefers-color-scheme: dark)').matches
-          ? 'dark'
-          : 'light')
-      );
+      return localStorage.getItem('theme') || 'light';
     }
     return 'light'; // Valeur par défaut côté serveur
   });
 
-  // Applique le thème au montage
+  // Applique le thème et le persiste à chaque changement
   useEffect(() => {
     document.documentElement.classList.remove('light', 'dark');
     document.documentElement.classList.add(theme);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,8 +11,16 @@ const slug = Astro.url.pathname;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 ---
 
-<html lang={lang} class="light">
+<html lang={lang}>
   <head>
+    <!-- Applique le thème persisté avant le rendu pour éviter le flash -->
+    <script is:inline>
+      (function () {
+        var theme = localStorage.getItem('theme') || 'light';
+        document.documentElement.classList.add(theme);
+      })();
+    </script>
+
     <!-- Encodage et compatibilité -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,6 +18,10 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
       (function () {
         var theme = localStorage.getItem('theme') || 'light';
         document.documentElement.classList.add(theme);
+        // Sans ça, un navigateur en préférence système sombre peint son
+        // canevas natif en noir avant que le CSS du site (qui dit "clair")
+        // ait chargé, provoquant un flash sombre même en thème light.
+        document.documentElement.style.colorScheme = theme;
       })();
     </script>
 


### PR DESCRIPTION
## Résumé

Le `ThemeSwitcher.jsx` lisait déjà/écrivait `localStorage`, mais le thème n'était appliqué qu'après hydratation du composant Preact (`client:load`), et `<html>` avait la classe `light` codée en dur dans `Layout.astro`. Résultat : flash du thème par défaut au chargement/rechargement, avant que React ne prenne le relais.

## Changements

- `src/layouts/Layout.astro` : ajout d'un script inline bloquant en tête du `<head>` qui lit `localStorage.getItem('theme')` (défaut `'light'`) et applique la classe sur `<html>` avant tout rendu. Suppression de la classe `light` codée en dur (désormais posée par le script).
- `src/components/ThemeSwitcher.jsx` : simplification de l'initialisation du state (plus de dépendance à `prefers-color-scheme`, hors scope du ticket) — le défaut est `'light'` si rien n'est stocké, cohérent avec le script du Layout. La persistance dans `localStorage` au toggle était déjà en place et est conservée.

## Critères d'acceptation

- [x] Le thème sélectionné est sauvegardé dans localStorage au moment du switch
- [x] Au chargement de la page, le thème est lu depuis localStorage et appliqué avant le rendu (pas de flash)
- [x] Le thème persiste après un rechargement de page (F5)
- [x] Le thème persiste après navigation entre les pages (script appliqué dans le `<head>` de chaque page via `Layout.astro`)
- [x] Si aucune préférence n'est stockée, un thème par défaut (`light`) est appliqué
- [x] Le switch de thème fonctionne dans les deux directions

## Test plan

- [x] `npm run build` passe sans erreur
- [x] Vérifié dans le HTML généré (`dist/fr/index.html`) que le script inline est bien présent en tête du `<head>`
- [x] `npx prettier --check` propre sur les fichiers modifiés

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JwD6gPGPBWr8bUFkvSFbW

---
_Generated by [Claude Code](https://claude.ai/code/session_014JwD6gPGPBWr8bUFkvSFbW)_