### PR TITLE
Add site footer (multi-column nav)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,47 @@
+---
+const { lang = 'fr' } = Astro.props;
+
+import { getTranslation } from '@utils/handleLocales';
+import SocialLinks from '@components/SocialLinks.astro';
+import Action from '@components/Action.astro';
+
+const content = getTranslation(lang);
+const currentYear = new Date().getFullYear();
+---
+
+<footer
+  class="w-full mt-16 border-t border-gray-300/50 dark:border-gray-700 bg-gray-100/40 dark:bg-gray-900/40 backdrop-blur-sm"
+>
+  <div
+    class="max-w-7xl mx-auto px-6 py-8 flex flex-col gap-6 md:flex-row md:items-center md:justify-between"
+  >
+    <div class="flex flex-col gap-1 text-center md:text-left">
+      <span class="font-bold text-gray-900 dark:text-gray-50"
+        >{content.hero.name}</span
+      >
+      <span class="text-sm text-gray-500 dark:text-gray-400">
+        © {currentYear} {content.hero.name} — {content.footer.rights}
+      </span>
+    </div>
+
+    <nav
+      aria-label={content.footer.navLabel}
+      class="flex flex-row justify-center gap-2"
+    >
+      <Action label={content.footer.home} lang={lang} link="" />
+    </nav>
+
+    <div class="flex flex-row flex-wrap justify-center gap-2">
+      {
+        content.socialLinks.map((link) => (
+          <SocialLinks
+            href={link.href}
+            label={link.label}
+            color={link.color}
+            icon={link.icon}
+          />
+        ))
+      }
+    </div>
+  </div>
+</footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,46 +2,70 @@
 const { lang = 'fr' } = Astro.props;
 
 import { getTranslation } from '@utils/handleLocales';
-import SocialLinks from '@components/SocialLinks.astro';
-import Action from '@components/Action.astro';
 
 const content = getTranslation(lang);
 const currentYear = new Date().getFullYear();
+
+const { projects, design, products, socials } = content.footer.nav;
+
+const linkClass =
+  'text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-50 transition-colors';
+const titleClass = 'text-sm font-bold text-gray-900 dark:text-gray-50';
+const placeholderClass = 'text-sm text-gray-400 dark:text-gray-500';
 ---
 
 <footer
   class="w-full mt-16 border-t border-gray-300/50 dark:border-gray-700 bg-gray-100/40 dark:bg-gray-900/40 backdrop-blur-sm"
 >
-  <div
-    class="max-w-7xl mx-auto px-6 py-8 flex flex-col gap-6 md:flex-row md:items-center md:justify-between"
-  >
-    <div class="flex flex-col gap-1 text-center md:text-left">
-      <span class="font-bold text-gray-900 dark:text-gray-50"
-        >{content.hero.name}</span
-      >
-      <span class="text-sm text-gray-500 dark:text-gray-400">
-        © {currentYear} {content.hero.name} — {content.footer.rights}
-      </span>
+  <div class="max-w-7xl mx-auto px-6 py-12 flex flex-col gap-10">
+    <span class="text-2xl font-bold text-gray-900 dark:text-gray-50">
+      {content.hero.name}
+    </span>
+
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-8">
+      <nav aria-label={projects.title} class="flex flex-col gap-3">
+        <span class={titleClass}>{projects.title}</span>
+        {
+          projects.items.map((item) => (
+            <a href={`/${lang}/${item.slug}/`} class={linkClass}>
+              {item.label}
+            </a>
+          ))
+        }
+      </nav>
+
+      <div class="flex flex-col gap-3">
+        <span class={titleClass}>{design.title}</span>
+        {design.items.map((item) => <span class={placeholderClass}>{item.label}</span>)}
+      </div>
+
+      <div class="flex flex-col gap-3">
+        <span class={titleClass}>{products.title}</span>
+        {products.items.map((item) => <span class={placeholderClass}>{item.label}</span>)}
+      </div>
+
+      <nav aria-label={socials.title} class="flex flex-col gap-3">
+        <span class={titleClass}>{socials.title}</span>
+        {
+          content.socialLinks.map((link) => (
+            <a
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              class={linkClass}
+              data-umami-event="click"
+              data-umami-event-id={link.label}
+              data-umami-event-type="social link"
+            >
+              {link.label}
+            </a>
+          ))
+        }
+      </nav>
     </div>
 
-    <nav
-      aria-label={content.footer.navLabel}
-      class="flex flex-row justify-center gap-2"
-    >
-      <Action label={content.footer.home} lang={lang} link="" />
-    </nav>
-
-    <div class="flex flex-row flex-wrap justify-center gap-2">
-      {
-        content.socialLinks.map((link) => (
-          <SocialLinks
-            href={link.href}
-            label={link.label}
-            color={link.color}
-            icon={link.icon}
-          />
-        ))
-      }
-    </div>
+    <span class="text-xs text-gray-500 dark:text-gray-400">
+      © {currentYear} {content.hero.name} — {content.footer.rights}
+    </span>
   </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,64 +8,73 @@ const currentYear = new Date().getFullYear();
 
 const { projects, design, products, socials } = content.footer.nav;
 
-const linkClass =
-  'text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-50 transition-colors';
-const titleClass = 'text-sm font-bold text-gray-900 dark:text-gray-50';
-const placeholderClass = 'text-sm text-gray-400 dark:text-gray-500';
+// Footer is a fixed dark surface (Penpot tokens surface.dark / onDark.*) —
+// it does not follow the site's light/dark theme toggle.
+const linkClass = 'text-base font-light text-white';
+const titleClass = 'text-base font-bold tracking-wide text-white';
+const placeholderClass = 'text-base font-light text-white';
 ---
 
-<footer
-  class="w-full mt-16 border-t border-gray-300/50 dark:border-gray-700 bg-gray-100/40 dark:bg-gray-900/40 backdrop-blur-sm"
->
-  <div class="max-w-7xl mx-auto px-6 py-12 flex flex-col gap-10">
-    <span class="text-2xl font-bold text-gray-900 dark:text-gray-50">
+<footer class="w-full mt-16 border-t border-gray-700 bg-gray-900">
+  <div class="max-w-7xl mx-auto px-12 py-12 flex flex-col gap-12">
+    <span class="font-avara text-4xl text-white">
       {content.hero.name}
     </span>
 
-    <div class="grid grid-cols-2 sm:grid-cols-4 gap-8">
-      <nav aria-label={projects.title} class="flex flex-col gap-3">
+    <div class="flex flex-wrap gap-x-12 gap-y-4">
+      <nav aria-label={projects.title} class="flex flex-col gap-2">
         <span class={titleClass}>{projects.title}</span>
-        {
-          projects.items.map((item) => (
-            <a href={`/${lang}/${item.slug}/`} class={linkClass}>
-              {item.label}
-            </a>
-          ))
-        }
+        <div class="flex flex-col gap-1">
+          {
+            projects.items.map((item) => (
+              <a href={`/${lang}/${item.slug}/`} class={linkClass}>
+                {item.label}
+              </a>
+            ))
+          }
+        </div>
       </nav>
 
-      <div class="flex flex-col gap-3">
+      <div class="flex flex-col gap-2">
         <span class={titleClass}>{design.title}</span>
-        {design.items.map((item) => <span class={placeholderClass}>{item.label}</span>)}
+        <div class="flex flex-col gap-1">
+          {design.items.map((item) => <span class={placeholderClass}>{item.label}</span>)}
+        </div>
       </div>
 
-      <div class="flex flex-col gap-3">
+      <div class="flex flex-col gap-2">
         <span class={titleClass}>{products.title}</span>
-        {products.items.map((item) => <span class={placeholderClass}>{item.label}</span>)}
+        <div class="flex flex-col gap-1">
+          {products.items.map((item) => <span class={placeholderClass}>{item.label}</span>)}
+        </div>
       </div>
 
-      <nav aria-label={socials.title} class="flex flex-col gap-3">
+      <nav aria-label={socials.title} class="flex flex-col gap-2">
         <span class={titleClass}>{socials.title}</span>
-        {
-          content.socialLinks.map((link) => (
-            <a
-              href={link.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              class={linkClass}
-              data-umami-event="click"
-              data-umami-event-id={link.label}
-              data-umami-event-type="social link"
-            >
-              {link.label}
-            </a>
-          ))
-        }
+        <div class="flex flex-col gap-1">
+          {
+            content.socialLinks.map((link) => (
+              <a
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                class={linkClass}
+                data-umami-event="click"
+                data-umami-event-id={link.label}
+                data-umami-event-type="social link"
+              >
+                {link.label}
+              </a>
+            ))
+          }
+        </div>
       </nav>
     </div>
 
-    <span class="text-xs text-gray-500 dark:text-gray-400">
-      © {currentYear} {content.hero.name} — {content.footer.rights}
-    </span>
+    <div class="w-full py-3">
+      <span class="text-xs text-gray-400">
+        © {currentYear} {content.hero.name} — {content.footer.rights}
+      </span>
+    </div>
   </div>
 </footer>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ const { pageTitle, description = '', class: classList, lang } = Astro.props;
 import '@styles/global.css';
 
 import Header from '@components/Header.astro';
+import Footer from '@components/Footer.astro';
 import UmamiPageViewer from '@analytics/UmamiPageViewer.astro';
 import OpenGraph from '@components/seo/OpenGraph.astro';
 
@@ -91,9 +92,10 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
     class="flex flex-col justify-start min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors"
   >
     <Header slug={slug} lang={lang}/>
-    <main class={classList}>
+    <main class={`flex-1 ${classList}`}>
       <slot />
     </main>
+    <Footer lang={lang} />
   </body>
 </html>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,5 +42,10 @@
       "text": "Let's talk",
       "url": "https://calendly.com/calendly-matchalo/30min"
     }
+  },
+  "footer": {
+    "navLabel": "Navigation",
+    "home": "Home",
+    "rights": "All rights reserved."
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -44,8 +44,21 @@
     }
   },
   "footer": {
-    "navLabel": "Navigation",
-    "home": "Home",
-    "rights": "All rights reserved."
+    "rights": "All rights reserved.",
+    "nav": {
+      "projects": {
+        "title": "Projects",
+        "items": [{ "label": "Unistellar", "slug": "unistellar" }]
+      },
+      "design": {
+        "title": "Design",
+        "items": [{ "label": "Components" }]
+      },
+      "products": {
+        "title": "Products",
+        "items": [{ "label": "Sketching tools" }]
+      },
+      "socials": { "title": "Socials" }
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -44,8 +44,21 @@
     }
   },
   "footer": {
-    "navLabel": "Navigation",
-    "home": "Accueil",
-    "rights": "Tous droits réservés."
+    "rights": "Tous droits réservés.",
+    "nav": {
+      "projects": {
+        "title": "Projets",
+        "items": [{ "label": "Unistellar", "slug": "unistellar" }]
+      },
+      "design": {
+        "title": "Design",
+        "items": [{ "label": "Composants" }]
+      },
+      "products": {
+        "title": "Produits",
+        "items": [{ "label": "Outils de sketch" }]
+      },
+      "socials": { "title": "Réseaux" }
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -42,5 +42,10 @@
       "text": "Parlons-en",
       "url": "https://calendly.com/calendly-matchalo/30min"
     }
+  },
+  "footer": {
+    "navLabel": "Navigation",
+    "home": "Accueil",
+    "rights": "Tous droits réservés."
   }
 }


### PR DESCRIPTION
## Summary
- Adds a `Footer.astro` component included in the shared `Layout.astro`, so it renders on every page (home, project pages, both locales)
- Multi-column layout matching the Penpot design: **Projets** (links to existing case studies), **Design** and **Produits** (upcoming sections, rendered as non-interactive placeholders since those pages don't exist yet), **Réseaux** (existing social links)
- Copyright line with the current year computed dynamically
- Makes `<main>` `flex-1` so the footer sticks to the bottom of the viewport on short pages

Closes #14

## Notes
- "Design > Composants" and "Produits > Outils de sketch" are plain text (no `<a href>`) until those pages exist, per the issue's "Hors Scope: Création de nouvelles pages liées depuis le footer"
- The "Projets" column is data-driven (`footer.nav.projects.items` in `fr.json`/`en.json`), so adding a second case study later just means adding an entry there alongside the existing routing/layout work — no footer changes needed

## Test plan
- [x] `npx astro build` succeeds and generates the footer on all pages (fr/en home, fr/en/unistellar, root)
- [x] Verified against the Penpot design in both light and dark mode via a local preview + screenshots
- [x] Responsive: 4 columns on desktop, 2-column wrap on mobile (390px viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ng1bsLEuW2sbjpPaHeaGtT